### PR TITLE
Add Hugging Face integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build/
 dist/
 build.sh
 *.job
+
+# Environments
+env/

--- a/hiera/__init__.py
+++ b/hiera/__init__.py
@@ -23,6 +23,7 @@ from .hiera import (
     MaskUnitAttention,
     Head,
     PatchEmbed,
+    HieraForImageClassification,
 )
 
 

--- a/hiera/hiera.py
+++ b/hiera/hiera.py
@@ -28,8 +28,9 @@ import torch.nn.functional as F
 
 from timm.models.layers import DropPath, Mlp
 
-from .hiera_utils import pretrained_model, conv_nd, do_pool, do_masked_conv, Unroll, Reroll
+from hiera_utils import pretrained_model, conv_nd, do_pool, do_masked_conv, Unroll, Reroll
 
+from huggingface_hub import PyTorchModelHubMixin
 
 
 class MaskUnitAttention(nn.Module):
@@ -225,12 +226,13 @@ class Hiera(nn.Module):
         patch_padding: Tuple[int, ...] = (3, 3),
         mlp_ratio: float = 4.0,
         drop_path_rate: float = 0.0,
-        norm_layer: nn.Module = partial(nn.LayerNorm, eps=1e-6),
         head_dropout: float = 0.0,
         head_init_scale: float = 0.001,
         sep_pos_embed: bool = False,
     ):
         super().__init__()
+
+        norm_layer: nn.Module = partial(nn.LayerNorm, eps=1e-6)
 
         depth = sum(stages)
         self.patch_stride = patch_stride
@@ -533,3 +535,9 @@ def hiera_huge_16x224(**kwdargs):
     return hiera_base_16x224(
         embed_dim=256, num_heads=4, stages=(2, 6, 36, 4), **kwdargs
     )
+
+
+# Hugging Face integration
+class HieraForImageClassification(Hiera, PyTorchModelHubMixin):
+    def __init__(self, config: dict):
+        super().__init__(**config)

--- a/hiera/hiera.py
+++ b/hiera/hiera.py
@@ -18,6 +18,7 @@
 # timm: https://github.com/rwightman/pytorch-image-models/tree/master/timm
 # --------------------------------------------------------
 
+import importlib.util
 import math
 from functools import partial
 from typing import List, Tuple, Callable, Optional
@@ -28,9 +29,15 @@ import torch.nn.functional as F
 
 from timm.models.layers import DropPath, Mlp
 
-from hiera_utils import pretrained_model, conv_nd, do_pool, do_masked_conv, Unroll, Reroll
+from .hiera_utils import pretrained_model, conv_nd, do_pool, do_masked_conv, Unroll, Reroll
 
-from huggingface_hub import PyTorchModelHubMixin
+
+def is_huggingface_hub_available():
+    return importlib.util.find_spec("huggingface_hub") is not None
+
+
+if is_huggingface_hub_available():
+    from huggingface_hub import PyTorchModelHubMixin
 
 
 class MaskUnitAttention(nn.Module):
@@ -535,7 +542,6 @@ def hiera_huge_16x224(**kwdargs):
     return hiera_base_16x224(
         embed_dim=256, num_heads=4, stages=(2, 6, 36, 4), **kwdargs
     )
-
 
 # Hugging Face integration
 class HieraForImageClassification(Hiera, PyTorchModelHubMixin):

--- a/hiera/hub_mixin.py
+++ b/hiera/hub_mixin.py
@@ -30,7 +30,7 @@ state_dict = torch.hub.load_state_dict_from_url("https://dl.fbaipublicfiles.com/
 model.load_state_dict(state_dict["model_state"])
 
 # save locally
-# model.save_pretrained("hiera-tiny-224")
+# model.save_pretrained("hiera-tiny-224", config=config)
 
 # save to huggingface hub
 # model.push_to_hub("nielsr/hiera-tiny-224", config=config)

--- a/hiera/hub_mixin.py
+++ b/hiera/hub_mixin.py
@@ -1,0 +1,39 @@
+
+import torch
+from hiera import HieraForImageClassification
+
+config = dict(embed_dim=96,
+            input_size=(224, 224),
+            in_chans=3,
+            num_heads=1,  # initial number of heads
+            num_classes=1000,
+            stages=(1, 2, 7, 2), 
+            q_pool=3,  # number of q_pool stages
+            q_stride=(2, 2),
+            mask_unit_size=(8, 8),  # must divide q_stride ** (#stages-1)
+            mask_unit_attn=(True, True, False, False),
+            dim_mul=2.0,
+            head_mul=2.0,
+            patch_kernel=(7, 7),
+            patch_stride=(4, 4),
+            patch_padding=(3, 3),
+            mlp_ratio=4.0,
+            drop_path_rate=0.0,
+            head_dropout=0.0,
+            head_init_scale=0.001,
+            sep_pos_embed=False,)
+
+model = HieraForImageClassification(config)
+
+# load weights
+state_dict = torch.hub.load_state_dict_from_url("https://dl.fbaipublicfiles.com/hiera/hiera_tiny_224.pth", map_location="cpu")
+model.load_state_dict(state_dict["model_state"])
+
+# save locally
+# model.save_pretrained("hiera-tiny-224")
+
+# save to huggingface hub
+# model.push_to_hub("nielsr/hiera-tiny-224", config=config)
+
+# load from huggingface hub
+model = HieraForImageClassification.from_pretrained("nielsr/hiera-tiny-224")


### PR DESCRIPTION
Hi @dbolya,

Thanks for this nice work. I wrote a quick PoC to showcase that you can easily have integration so that you can automatically load the various Hiera models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from cotracker.models.core.cotracker.cotracker import CoTracker2

model = CoTracker2.from_pretrained("nielsr/co-tracker-hf")
```
The corresponding model is here for now: https://huggingface.co/nielsr/co-tracker-hf. We could move all checkpoints to separate repos on the [Meta organization](https://huggingface.co/facebook) if you're interested. Ideally, each checkpoint has its own model repository on the 🤗 hub, where a config.json and safetensors weights are hosted.

To improve discoverability, we could add tags like "object-tracking" to the model cards, so that people can find these models by either typing in the search bar/filtering on hf.co/models.

Would you be interested in this integration?

Kind regards,

Niels